### PR TITLE
Reverted 0.8.x upgrade and then updated Registrar

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1,5 +1,10 @@
 {
-  "manifestVersion": "3.1",
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xf05362726F7aE801E6e395Ac562E9D38700F7f94",
+    "txHash": "0xa5451ac1598a806ac28356a28e6ff2b86029116e17cc794c38270139ce0ee441"
+  },
+  "proxies": [],
   "impls": {
     "766d00de356fb546c4841d9b362b1625961bbdeae5f4c8db416d2446b6201568": {
       "address": "0xD09deB717F97012068F4795AE1389650197895c5",
@@ -674,10 +679,285 @@
           }
         }
       }
+    },
+    "67ca01a69560a9decb16240d0b4175a571168ae7774d17997ffd2843e7d0ac93": {
+      "address": "0x2686dC2e1bC5774441ec6a4A6cd6E47dEf934baE",
+      "txHash": "0x39a8bbce5db9ffccf5f1c255cb014fa9a107089771116c4beb223c32a9f64412",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\Initializable.sol:25"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin\\contracts-upgradeable\\proxy\\Initializable.sol:30"
+          },
+          {
+            "contract": "ContextUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\ContextUpgradeable.sol:31"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "_supportedInterfaces",
+            "type": "t_mapping(t_bytes4,t_bool)",
+            "src": "@openzeppelin\\contracts-upgradeable\\introspection\\ERC165Upgradeable.sol:23"
+          },
+          {
+            "contract": "ERC165Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\introspection\\ERC165Upgradeable.sol:59"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "_owner",
+            "type": "t_address",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:20"
+          },
+          {
+            "contract": "OwnableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\access\\OwnableUpgradeable.sol:74"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_holderTokens",
+            "type": "t_mapping(t_address,t_struct(UintSet)3988_storage)",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:34"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenOwners",
+            "type": "t_struct(UintToAddressMap)3365_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:37"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenApprovals",
+            "type": "t_mapping(t_uint256,t_address)",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:40"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_operatorApprovals",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:43"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_name",
+            "type": "t_string_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:46"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_symbol",
+            "type": "t_string_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:49"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_tokenURIs",
+            "type": "t_mapping(t_uint256,t_string_storage)",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:52"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "_baseURI",
+            "type": "t_string_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:55"
+          },
+          {
+            "contract": "ERC721Upgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)41_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721Upgradeable.sol:485"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "_paused",
+            "type": "t_bool",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:28"
+          },
+          {
+            "contract": "PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)49_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\utils\\PausableUpgradeable.sol:96"
+          },
+          {
+            "contract": "ERC721PausableUpgradeable",
+            "label": "__gap",
+            "type": "t_array(t_uint256)50_storage",
+            "src": "@openzeppelin\\contracts-upgradeable\\token\\ERC721\\ERC721PausableUpgradeable.sol:38"
+          },
+          {
+            "contract": "Registrar",
+            "label": "controllers",
+            "type": "t_mapping(t_address,t_bool)",
+            "src": "contracts\\Registrar.sol:24"
+          },
+          {
+            "contract": "Registrar",
+            "label": "records",
+            "type": "t_mapping(t_uint256,t_struct(DomainRecord)4505_storage)",
+            "src": "contracts\\Registrar.sol:28"
+          }
+        ],
+        "types": {
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)"
+          },
+          "t_address": {
+            "label": "address"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_uint256,t_struct(DomainRecord)4505_storage)": {
+            "label": "mapping(uint256 => struct Registrar.DomainRecord)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_struct(DomainRecord)4505_storage": {
+            "label": "struct Registrar.DomainRecord",
+            "members": [
+              {
+                "label": "minter",
+                "type": "t_address"
+              },
+              {
+                "label": "metadataLocked",
+                "type": "t_bool"
+              },
+              {
+                "label": "metadataLockedBy",
+                "type": "t_address"
+              },
+              {
+                "label": "controller",
+                "type": "t_address"
+              },
+              {
+                "label": "royaltyAmount",
+                "type": "t_uint256"
+              },
+              {
+                "label": "parentId",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]"
+          },
+          "t_mapping(t_address,t_struct(UintSet)3988_storage)": {
+            "label": "mapping(address => struct EnumerableSetUpgradeable.UintSet)"
+          },
+          "t_struct(UintSet)3988_storage": {
+            "label": "struct EnumerableSetUpgradeable.UintSet",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Set)3602_storage"
+              }
+            ]
+          },
+          "t_struct(Set)3602_storage": {
+            "label": "struct EnumerableSetUpgradeable.Set",
+            "members": [
+              {
+                "label": "_values",
+                "type": "t_array(t_bytes32)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]"
+          },
+          "t_bytes32": {
+            "label": "bytes32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)"
+          },
+          "t_struct(UintToAddressMap)3365_storage": {
+            "label": "struct EnumerableMapUpgradeable.UintToAddressMap",
+            "members": [
+              {
+                "label": "_inner",
+                "type": "t_struct(Map)3047_storage"
+              }
+            ]
+          },
+          "t_struct(Map)3047_storage": {
+            "label": "struct EnumerableMapUpgradeable.Map",
+            "members": [
+              {
+                "label": "_entries",
+                "type": "t_array(t_struct(MapEntry)3039_storage)dyn_storage"
+              },
+              {
+                "label": "_indexes",
+                "type": "t_mapping(t_bytes32,t_uint256)"
+              }
+            ]
+          },
+          "t_array(t_struct(MapEntry)3039_storage)dyn_storage": {
+            "label": "struct EnumerableMapUpgradeable.MapEntry[]"
+          },
+          "t_struct(MapEntry)3039_storage": {
+            "label": "struct EnumerableMapUpgradeable.MapEntry",
+            "members": [
+              {
+                "label": "_key",
+                "type": "t_bytes32"
+              },
+              {
+                "label": "_value",
+                "type": "t_bytes32"
+              }
+            ]
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_mapping(t_uint256,t_string_storage)": {
+            "label": "mapping(uint256 => string)"
+          },
+          "t_array(t_uint256)41_storage": {
+            "label": "uint256[41]"
+          },
+          "t_mapping(t_bytes4,t_bool)": {
+            "label": "mapping(bytes4 => bool)"
+          },
+          "t_bytes4": {
+            "label": "bytes4"
+          }
+        }
+      }
     }
-  },
-  "admin": {
-    "address": "0xf05362726F7aE801E6e395Ac562E9D38700F7f94",
-    "txHash": "0xa5451ac1598a806ac28356a28e6ff2b86029116e17cc794c38270139ce0ee441"
   }
 }

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -18,7 +18,6 @@ contract Registrar is
     address controller;
     uint256 royaltyAmount;
     uint256 parentId;
-    uint256 nonce;
   }
 
   // A map of addresses that are authorised to register domains.
@@ -298,17 +297,6 @@ contract Registrar is
     return parentId;
   }
 
-  /**
-   * @notice Returns the domain nonce of a domain.
-   * @param id The domain
-   */
-  function domainNonce(uint256 id) public view override returns (uint256) {
-    require(_exists(id), "Zer0 Registrar: Does not exist");
-
-    uint256 nonce = records[id].nonce;
-    return nonce;
-  }
-
   /*
    * Internal Methods
    */
@@ -323,15 +311,13 @@ contract Registrar is
   ) internal {
     // Create the NFT and register the domain data
     _safeMint(domainOwner, domainId);
-    uint256 lastNonce = records[domainId].nonce; // default to zero
     records[domainId] = DomainRecord({
       parentId: parentId,
       minter: minter,
       metadataLocked: false,
       metadataLockedBy: address(0),
       controller: controller,
-      royaltyAmount: 0,
-      nonce: lastNonce + 1
+      royaltyAmount: 0
     });
   }
 

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -195,6 +195,24 @@ contract Registrar is
     _unlockMetadata(id);
   }
 
+  function fixParentLink(uint256 parentId, string memory name) external {
+    uint256 labelHash = uint256(keccak256(bytes(name)));
+
+    // Domain parents must exist
+    require(_exists(parentId), "No parent");
+
+    // Calculate the new domain's id and create it
+    uint256 domainId = uint256(
+      keccak256(abi.encodePacked(parentId, labelHash))
+    );
+
+    require(_exists(domainId), "Invalid domain");
+
+    require(records[domainId].parentId == 0, "Parent Already Set");
+
+    records[domainId].parentId = parentId;
+  }
+
   /*
    * Public View
    */

--- a/contracts/StakingController.sol
+++ b/contracts/StakingController.sol
@@ -158,8 +158,10 @@ contract StakingController is
     );
     require(!request.accepted, "Staking Controller: Request already accepted");
 
-    uint256 domainId =
-      calculateDomainId(request.parentId, request.requestedName);
+    uint256 domainId = calculateDomainId(
+      request.parentId,
+      request.requestedName
+    );
 
     require(
       request.domainNonce == domainData[domainId].nonce,
@@ -195,8 +197,10 @@ contract StakingController is
 
     require(request.accepted, "Staking Controller: Request not accepted");
 
-    uint256 predictedDomainId =
-      calculateDomainId(request.parentId, request.requestedName);
+    uint256 predictedDomainId = calculateDomainId(
+      request.parentId,
+      request.requestedName
+    );
 
     require(
       request.domainNonce == domainData[predictedDomainId].nonce,
@@ -221,13 +225,12 @@ contract StakingController is
     );
 
     // This will fail if the domain already exists
-    uint256 domainId =
-      registrar.registerDomain(
-        request.parentId,
-        request.requestedName,
-        controller,
-        request.requester
-      );
+    uint256 domainId = registrar.registerDomain(
+      request.parentId,
+      request.requestedName,
+      controller,
+      request.requester
+    );
 
     /*
      * This should never really happen, but if it does it means the controller
@@ -333,8 +336,9 @@ contract StakingController is
     returns (uint256)
   {
     uint256 labelHash = uint256(keccak256(bytes(name)));
-    uint256 domainId =
-      uint256(keccak256(abi.encodePacked(parentId, labelHash)));
+    uint256 domainId = uint256(
+      keccak256(abi.encodePacked(parentId, labelHash))
+    );
 
     return domainId;
   }

--- a/contracts/StakingController.sol
+++ b/contracts/StakingController.sol
@@ -158,10 +158,8 @@ contract StakingController is
     );
     require(!request.accepted, "Staking Controller: Request already accepted");
 
-    uint256 domainId = calculateDomainId(
-      request.parentId,
-      request.requestedName
-    );
+    uint256 domainId =
+      calculateDomainId(request.parentId, request.requestedName);
 
     require(
       request.domainNonce == domainData[domainId].nonce,
@@ -197,10 +195,8 @@ contract StakingController is
 
     require(request.accepted, "Staking Controller: Request not accepted");
 
-    uint256 predictedDomainId = calculateDomainId(
-      request.parentId,
-      request.requestedName
-    );
+    uint256 predictedDomainId =
+      calculateDomainId(request.parentId, request.requestedName);
 
     require(
       request.domainNonce == domainData[predictedDomainId].nonce,
@@ -225,12 +221,13 @@ contract StakingController is
     );
 
     // This will fail if the domain already exists
-    uint256 domainId = registrar.registerDomain(
-      request.parentId,
-      request.requestedName,
-      controller,
-      request.requester
-    );
+    uint256 domainId =
+      registrar.registerDomain(
+        request.parentId,
+        request.requestedName,
+        controller,
+        request.requester
+      );
 
     /*
      * This should never really happen, but if it does it means the controller
@@ -336,9 +333,8 @@ contract StakingController is
     returns (uint256)
   {
     uint256 labelHash = uint256(keccak256(bytes(name)));
-    uint256 domainId = uint256(
-      keccak256(abi.encodePacked(parentId, labelHash))
-    );
+    uint256 domainId =
+      uint256(keccak256(abi.encodePacked(parentId, labelHash)));
 
     return domainId;
   }

--- a/contracts/StakingController.sol
+++ b/contracts/StakingController.sol
@@ -29,8 +29,6 @@ contract StakingController is
   uint256 public requestCount;
 
   struct DomainData {
-    // Used to invalidate all existing requests whenever a request is fulfilled
-    uint256 nonce;
     // Tracks the request which was fulfilled to create this domain
     uint256 fulfilledRequestId;
     // Tracks the current (actual) domain token of a domain (will always be a token)
@@ -48,7 +46,6 @@ contract StakingController is
     address requester;
     string requestedName;
     bool accepted;
-    uint256 domainNonce;
     address domainToken; // may be address(0)
     bool fulfilled;
   }
@@ -113,15 +110,12 @@ contract StakingController is
       "Staking Controller: Domain already exists."
     );
 
-    uint256 domainNonce = domainData[domainId].nonce;
-
     requests[requestCount] = Request({
       parentId: parentId,
       offeredAmount: offeredAmount,
       requester: _msgSender(),
       requestedName: name,
       accepted: false,
-      domainNonce: domainNonce,
       domainToken: domainToken,
       fulfilled: false
     });
@@ -133,7 +127,6 @@ contract StakingController is
       requestUri,
       name,
       _msgSender(),
-      domainNonce,
       domainToken
     );
   }
@@ -164,8 +157,8 @@ contract StakingController is
     );
 
     require(
-      request.domainNonce == domainData[domainId].nonce,
-      "Staking Controller: Request is outdated"
+      domainData[domainId].fulfilledRequestId == 0,
+      "Staking Controller: Request is outdated."
     );
 
     request.accepted = true;
@@ -203,13 +196,13 @@ contract StakingController is
     );
 
     require(
-      request.domainNonce == domainData[predictedDomainId].nonce,
-      "Staking Controller: Request is outdated."
+      !request.fulfilled,
+      "Staking Controller: Request already fulfilled."
     );
 
     require(
-      !request.fulfilled,
-      "Staking Controller: Request already fulfilled."
+      domainData[predictedDomainId].fulfilledRequestId == 0,
+      "Staking Controller: Request is outdated."
     );
 
     request.fulfilled = true;
@@ -242,9 +235,6 @@ contract StakingController is
       "Staking Controller: internal error, domain id's did not match."
     );
 
-    // Update the domain nonce so any previous requests are now invalid
-    uint256 newDomainNonce = registrar.domainNonce(domainId);
-    domainData[domainId].nonce = newDomainNonce;
     // Track the request which was fulfilled for this domain
     domainData[domainId].fulfilledRequestId = requestId;
 
@@ -272,7 +262,6 @@ contract StakingController is
       request.requester,
       domainId,
       request.parentId,
-      newDomainNonce,
       domainData[domainId].domainToken
     );
   }
@@ -287,16 +276,11 @@ contract StakingController is
     external
     authorized(domainId)
   {
-    uint256 domainNonce = registrar.domainNonce(domainId);
-    if (
-      domainData[domainId].domainToken != address(0) &&
-      domainNonce == domainData[domainId].nonce
-    ) {
+    if (domainData[domainId].domainToken != address(0)) {
       revert("Staking Controller: Domain Token already set.");
     }
 
     domainData[domainId].domainToken = token;
-    domainData[domainId].nonce = domainNonce;
 
     emit DomainTokenSet(domainId, token);
   }

--- a/contracts/StakingController.sol
+++ b/contracts/StakingController.sol
@@ -157,8 +157,8 @@ contract StakingController is
     );
 
     require(
-      domainData[domainId].fulfilledRequestId == 0,
-      "Staking Controller: Request is outdated."
+      !registrar.domainExists(domainId),
+      "Staking Controller: Domain already exists."
     );
 
     request.accepted = true;
@@ -201,8 +201,8 @@ contract StakingController is
     );
 
     require(
-      domainData[predictedDomainId].fulfilledRequestId == 0,
-      "Staking Controller: Request is outdated."
+      !registrar.domainExists(predictedDomainId),
+      "Staking Controller: Domain already exists."
     );
 
     request.fulfilled = true;

--- a/contracts/interfaces/IRegistrar.sol
+++ b/contracts/interfaces/IRegistrar.sol
@@ -91,7 +91,4 @@ interface IRegistrar is
 
   // Returns the parent domain of a child domain
   function parentOf(uint256 id) external view returns (uint256);
-
-  // Returns the current domain nonce
-  function domainNonce(uint256 id) external view returns (uint256);
 }

--- a/contracts/interfaces/IStakingController.sol
+++ b/contracts/interfaces/IStakingController.sol
@@ -12,7 +12,6 @@ interface IStakingController is IERC165Upgradeable, IERC721ReceiverUpgradeable {
     string requestUri,
     string indexed name,
     address requestor,
-    uint256 domainNonce,
     address domainToken
   );
 
@@ -24,7 +23,6 @@ interface IStakingController is IERC165Upgradeable, IERC721ReceiverUpgradeable {
     address recipient,
     uint256 indexed domainId,
     uint256 indexed parentID,
-    uint256 domainNonce,
     address domainToken
   );
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -28,6 +28,9 @@ const config: HardhatUserConfig = {
               "*": ["storageLayout"],
             },
           },
+          optimizer: {
+            enabled: true,
+          },
         },
       },
     ],
@@ -49,7 +52,7 @@ const config: HardhatUserConfig = {
     mainnet: {
       accounts: { mnemonic: process.env.MAINNET_MNEMONIC || "" },
       url: `https://mainnet.infura.io/v3/0e6434f252a949719227b5d68caa2657`,
-      gasPrice: 45000000000,
+      gasPrice: 100000000000,
     },
     kovan: {
       accounts: { mnemonic: process.env.TESTNET_MNEMONIC || "" },

--- a/scripts/cancel-tx.ts
+++ b/scripts/cancel-tx.ts
@@ -1,0 +1,15 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const accounts = await ethers.getSigners();
+  const signer = accounts[0];
+
+  await signer.sendTransaction({
+    to: signer.address,
+    value: 0,
+    nonce: 62,
+    gasPrice: 100000000000,
+  });
+}
+
+main();

--- a/scripts/test-upgrade.ts
+++ b/scripts/test-upgrade.ts
@@ -1,33 +1,32 @@
 import { ethers, upgrades, network, run } from "hardhat";
+import { Registrar__factory } from "../typechain";
 import { getLogger } from "../utilities";
 
 //const logger = getLogger("scripts::deploy-registrar");
 
 async function main() {
-  //const accounts = await ethers.getSigners();
+  const accounts = await ethers.getSigners();
+  const signer = accounts[0];
 
-  await network.provider.request({
-    method: "hardhat_impersonateAccount",
-    params: ["0x37358aa5d051b434c23bad744e56e6a484107272"],
-  });
+  // await network.provider.request({
+  //   method: "hardhat_impersonateAccount",
+  //   params: ["0x37358aa5d051b434c23bad744e56e6a484107272"],
+  // });
 
-  const signer = await ethers.getSigner(
-    "0x37358aa5d051b434c23bad744e56e6a484107272"
-  );
+  // const signer = await ethers.getSigner(
+  //   "0x37358aa5d051b434c23bad744e56e6a484107272"
+  // );
 
-  await network.provider.send("hardhat_setBalance", [
-    "0x37358aa5d051b434c23bad744e56e6a484107272",
-    "0x56BC75E2D63100000",
-  ]);
+  // await network.provider.send("hardhat_setBalance", [
+  //   "0x37358aa5d051b434c23bad744e56e6a484107272",
+  //   "0x56BC75E2D63100000",
+  // ]);
 
   const registrarFactory = await ethers.getContractFactory("Registrar", signer);
 
-  const res = await upgrades.prepareUpgrade(
-    "0xc2e9678A71e50E5AEd036e00e9c5caeb1aC5987D",
-    registrarFactory
-  );
+  const proxyAddress = "0xc2e9678A71e50E5AEd036e00e9c5caeb1aC5987D";
 
-  console.log(res);
+  await upgrades.upgradeProxy(proxyAddress, registrarFactory);
 }
 
 main();

--- a/test/e2e.stakingcontroller.spec.ts
+++ b/test/e2e.stakingcontroller.spec.ts
@@ -84,8 +84,6 @@ describe("Staking Controller", () => {
         ethers.constants.AddressZero
       );
 
-      const expectedNonce = 0;
-
       expect(tx)
         .to.emit(controller, "DomainRequestPlaced")
         .withArgs(
@@ -95,7 +93,6 @@ describe("Staking Controller", () => {
           requestUri,
           name,
           user1.address,
-          expectedNonce,
           ethers.constants.AddressZero
         );
     });
@@ -166,8 +163,6 @@ describe("Staking Controller", () => {
         lock
       );
 
-      const expectedNonce = 1;
-
       expect(tx)
         .to.emit(controller, "DomainRequestFulfilled")
         .withArgs(
@@ -176,7 +171,6 @@ describe("Staking Controller", () => {
           user1.address,
           expectedId,
           parentID,
-          expectedNonce,
           mockTokenSmock.address
         );
     });
@@ -187,7 +181,7 @@ describe("Staking Controller", () => {
 
       await expect(
         controllerAsUser1.fulfillDomainRequest(1, royaltyAmount, metadata, lock)
-      ).to.be.revertedWith("Staking Controller: Request is outdated");
+      ).to.be.revertedWith("Staking Controller: Request already fulfilled.");
     });
   });
 
@@ -205,8 +199,6 @@ describe("Staking Controller", () => {
         mockTokenSmock.address
       );
 
-      const expectedNonce = 0;
-
       expect(tx)
         .to.emit(controller, "DomainRequestPlaced")
         .withArgs(
@@ -216,7 +208,6 @@ describe("Staking Controller", () => {
           requestUri,
           otherDomainName,
           user1.address,
-          expectedNonce,
           mockTokenSmock.address
         );
 

--- a/test/e2e.stakingcontroller.spec.ts
+++ b/test/e2e.stakingcontroller.spec.ts
@@ -245,12 +245,12 @@ describe("Staking Controller", () => {
       const controllerAsUser1 = await controller.connect(user1);
       await expect(
         controllerAsUser1.fulfillDomainRequest(3, 0, "meta", true)
-      ).to.be.revertedWith("Staking Controller: Request is outdated");
+      ).to.be.revertedWith("Staking Controller: Domain already exists.");
     });
 
     it("fails to accept the third bid", async () => {
       await expect(controller.approveDomainRequest(4)).to.be.revertedWith(
-        "Staking Controller: Request is outdated"
+        "Staking Controller: Domain already exists."
       );
     });
   });


### PR DESCRIPTION
- Reverted contract code to be 0.7.x again
- Made it so the registrar keeps track of parent id links
- Staking controller supports multiple tokens
- Upgraded mainnet registrar