### PR TITLE
Authorized Basic Controller

### DIFF
--- a/contracts/AuthBasicController.sol
+++ b/contracts/AuthBasicController.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./interfaces/IBasicController.sol";
 import "./interfaces/IRegistrar.sol";
 
-contract BasicController is
+contract AuthBasicController is
   IBasicController,
   ContextUpgradeable,
   ERC165Upgradeable,

--- a/contracts/AuthBasicController.sol
+++ b/contracts/AuthBasicController.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.7.3;
+
+import "@openzeppelin/contracts-upgradeable/proxy/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/introspection/ERC165Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721HolderUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+
+import "./interfaces/IBasicController.sol";
+import "./interfaces/IRegistrar.sol";
+
+contract BasicController is
+  IBasicController,
+  ContextUpgradeable,
+  ERC165Upgradeable,
+  ERC721HolderUpgradeable,
+  OwnableUpgradeable
+{
+  IRegistrar private registrar;
+
+  modifier authorized() {
+    require(owner() == _msgSender(), "Zer0 Controller: Not Authorized");
+    _;
+  }
+
+  function initialize(IRegistrar _registrar) public initializer {
+    __ERC165_init();
+    __Context_init();
+    __ERC721Holder_init();
+    __Ownable_init();
+
+    registrar = _registrar;
+  }
+
+  function registerSubdomainExtended(
+    uint256 parentId,
+    string memory label,
+    address owner,
+    string memory metadata,
+    uint256 royaltyAmount,
+    bool lockOnCreation
+  ) external override authorized returns (uint256) {
+    address minter = _msgSender();
+
+    uint256 id = registrar.registerDomainAndSend(
+      parentId,
+      label,
+      minter,
+      metadata,
+      royaltyAmount,
+      lockOnCreation,
+      owner
+    );
+
+    return id;
+  }
+}

--- a/contracts/AuthBasicController.sol
+++ b/contracts/AuthBasicController.sol
@@ -18,9 +18,15 @@ contract AuthBasicController is
   OwnableUpgradeable
 {
   IRegistrar private registrar;
+  mapping(address => bool) public authorizedAccounts;
+
+  event AccountAuthorizationChanged(address account, bool isAuthorized);
 
   modifier authorized() {
-    require(owner() == _msgSender(), "Zer0 Controller: Not Authorized");
+    require(
+      authorizedAccounts[_msgSender()] || _msgSender() == owner(),
+      "Not Authorized"
+    );
     _;
   }
 
@@ -31,6 +37,19 @@ contract AuthBasicController is
     __Ownable_init();
 
     registrar = _registrar;
+  }
+
+  function setAccountAuthorizationStatus(address account, bool isAuthorized)
+    external
+    onlyOwner
+  {
+    if (isAuthorized) {
+      require(!authorizedAccounts[account], "Account already authorized");
+    } else {
+      require(authorizedAccounts[account], "Account already not authorized");
+    }
+    authorizedAccounts[account] = isAuthorized;
+    emit AccountAuthorizationChanged(account, isAuthorized);
   }
 
   function registerSubdomainExtended(

--- a/contracts/AuthBasicController.sol
+++ b/contracts/AuthBasicController.sol
@@ -56,7 +56,7 @@ contract AuthBasicController is
     uint256 parentId,
     string memory label,
     address owner,
-    string memory metadata,
+    string memory metadataUri,
     uint256 royaltyAmount,
     bool lockOnCreation
   ) external override authorized returns (uint256) {
@@ -66,7 +66,7 @@ contract AuthBasicController is
       parentId,
       label,
       minter,
-      metadata,
+      metadataUri,
       royaltyAmount,
       lockOnCreation,
       owner

--- a/contracts/Registrar.sol
+++ b/contracts/Registrar.sol
@@ -108,6 +108,50 @@ contract Registrar is
     uint256 royaltyAmount,
     bool locked
   ) external override onlyController returns (uint256) {
+    return
+      _registerDomain(
+        parentId,
+        name,
+        minter,
+        metadataUri,
+        royaltyAmount,
+        locked
+      );
+  }
+
+  function registerDomainAndSend(
+    uint256 parentId,
+    string memory name,
+    address minter,
+    string memory metadataUri,
+    uint256 royaltyAmount,
+    bool locked,
+    address sendToUser
+  ) external override onlyController returns (uint256) {
+    // Register the domain
+    uint256 id = _registerDomain(
+      parentId,
+      name,
+      minter,
+      metadataUri,
+      royaltyAmount,
+      locked
+    );
+
+    // immediately send domain to user
+    _safeTransfer(minter, sendToUser, id, "");
+
+    return id;
+  }
+
+  function _registerDomain(
+    uint256 parentId,
+    string memory name,
+    address minter,
+    string memory metadataUri,
+    uint256 royaltyAmount,
+    bool locked
+  ) internal returns (uint256) {
     require(bytes(name).length > 0, "Zer0 Registrar: Empty name");
 
     // Create the child domain under the parent domain
@@ -325,7 +369,7 @@ contract Registrar is
     address controller
   ) internal {
     // Create the NFT and register the domain data
-    _safeMint(minter, domainId);
+    _mint(minter, domainId);
     records[domainId] = DomainRecord({
       parentId: parentId,
       minter: minter,

--- a/contracts/interfaces/IRegistrar.sol
+++ b/contracts/interfaces/IRegistrar.sol
@@ -51,6 +51,16 @@ interface IRegistrar is
     bool locked
   ) external returns (uint256);
 
+  function registerDomainAndSend(
+    uint256 parentId,
+    string memory name,
+    address minter,
+    string memory metadataUri,
+    uint256 royaltyAmount,
+    bool locked,
+    address sendToUser
+  ) external returns (uint256);
+
   // Set a domains metadata uri and lock that domain from being modified
   function setAndLockDomainMetadata(uint256 id, string memory uri) external;
 


### PR DESCRIPTION
Added a Basic Controller which only allows authorized users to mint domains.
For now it allows global minting abilities.
Also added a new function on the Registrar which will mint + send a domain to a user. This is a common use case.