### PR TITLE
Fix resource type authorization

### DIFF
--- a/contracts/interfaces/IResourceRegistry.sol
+++ b/contracts/interfaces/IResourceRegistry.sol
@@ -3,5 +3,5 @@
 pragma solidity ^0.8.0;
 
 interface IResourceRegistry {
-  function resourceExists(uint256 _resourceID) external view returns (bool);
+  function resourceExists(uint256 resourceID) external view returns (bool);
 }

--- a/contracts/interfaces/IZNAResolver.sol
+++ b/contracts/interfaces/IZNAResolver.sol
@@ -10,22 +10,22 @@ interface IZNAResolver {
   /* -------------------------------------------------------------------------- */
 
   event ResourceAssociated(
-    uint256 _zNA,
-    uint256 _resourceType,
-    uint256 _resourceID
+    uint256 zNA,
+    uint256 resourceType,
+    uint256 resourceID
   );
 
   event ResourceDisassociated(
-    uint256 _zNA,
-    uint256 _resourceType,
-    uint256 _oldResourceID
+    uint256 zNA,
+    uint256 oldResourceType,
+    uint256 oldResourceID
   );
 
-  event ResourceRegistryAdded(uint256 _resourceType, address _resourceRegistry);
+  event ResourceRegistryAdded(uint256 resourceType, address resourceRegistry);
 
   event ResourceRegistryRemoved(
-    uint256 _resourceType,
-    address _oldResourceRegistry
+    uint256 oldResourceType,
+    address oldResourceRegistry
   );
 
   /* -------------------------------------------------------------------------- */
@@ -33,38 +33,38 @@ interface IZNAResolver {
   /* -------------------------------------------------------------------------- */
 
   function associateWithResourceType(
-    uint256 _zNA,
-    uint256 _resourceType,
-    uint256 _resourceID
+    uint256 zNA,
+    uint256 resourceType,
+    uint256 resourceID
   ) external;
 
-  function disassociateWithResourceType(uint256 _zNA, uint256 _resourceType)
+  function disassociateWithResourceType(uint256 zNA, uint256 resourceType)
     external;
 
   function addResourceRegistry(
-    uint256 _resourceType,
-    IResourceRegistry _resourceRegistry
+    uint256 resourceType,
+    IResourceRegistry resourceRegistry
   ) external;
 
-  function removeResourceRegistry(uint256 _resourceType) external;
+  function removeResourceRegistry(uint256 resourceType) external;
 
   /* -------------------------------------------------------------------------- */
   /*                               View Functions                               */
   /* -------------------------------------------------------------------------- */
 
-  function hasResourceType(uint256 _zNA, uint256 _resourceType)
+  function hasResourceType(uint256 zNA, uint256 resourceType)
     external
     view
     returns (bool);
 
-  function resourceTypes(uint256 _zNA) external view returns (uint256);
+  function resourceTypes(uint256 zNA) external view returns (uint256);
 
-  function resourceID(uint256 _zNA, uint256 _resourceType)
+  function resourceID(uint256 zNA, uint256 resourceType)
     external
     view
     returns (uint256);
 
-  function resourceRegistry(uint256 _resourceType)
+  function resourceRegistry(uint256 resourceType)
     external
     view
     returns (IResourceRegistry);

--- a/contracts/libraries/ResourceType.sol
+++ b/contracts/libraries/ResourceType.sol
@@ -4,5 +4,4 @@ pragma solidity ^0.8.11;
 library ResourceType {
   uint256 public constant RESOURCE_TYPE_DAO = 0x1;
   uint256 public constant RESOURCE_TYPE_STAKING_POOL = 0x2;
-  uint256 public constant RESOURCE_TYPE_FARMING = 0x4;
 }

--- a/contracts/libraries/ResourceType.sol
+++ b/contracts/libraries/ResourceType.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+library ResourceType {
+  uint256 public constant RESOURCE_TYPE_DAO = 0x1;
+  uint256 public constant RESOURCE_TYPE_STAKING_POOL = 0x2;
+  uint256 public constant RESOURCE_TYPE_FARMING = 0x4;
+}

--- a/contracts/mocks/MockResourceRegistry.sol
+++ b/contracts/mocks/MockResourceRegistry.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.11;
+
+import {IResourceRegistry} from "../interfaces/IResourceRegistry.sol";
+import {IZNAResolver} from "../interfaces/IZNAResolver.sol";
+
+contract MockResourceRegistry is IResourceRegistry {
+  uint256 public immutable resourceType;
+
+  IZNAResolver public immutable zNAResolver;
+
+  uint256 public lastResourceID;
+  mapping(uint256 => bool) public resourceMapping;
+
+  /* -------------------------------------------------------------------------- */
+  /*                                  Modifiers                                 */
+  /* -------------------------------------------------------------------------- */
+
+  /* -------------------------------------------------------------------------- */
+  /*                                 Constructor                                */
+  /* -------------------------------------------------------------------------- */
+
+  constructor(uint256 _resourceType, IZNAResolver _zNAResolver) {
+    resourceType = _resourceType;
+    zNAResolver = _zNAResolver;
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                             External Functions                             */
+  /* -------------------------------------------------------------------------- */
+
+  function addResource(uint256 _zNA) external returns (uint256) {
+    ++lastResourceID;
+    resourceMapping[lastResourceID] = true;
+
+    zNAResolver.associateWithResourceType(_zNA, resourceType, lastResourceID);
+    return lastResourceID;
+  }
+
+  function addResourceExploit(uint256 _zNA, uint256 _resourceType)
+    external
+    returns (uint256)
+  {
+    ++lastResourceID;
+    resourceMapping[lastResourceID] = true;
+
+    zNAResolver.associateWithResourceType(_zNA, _resourceType, lastResourceID);
+    return lastResourceID;
+  }
+
+  /* -------------------------------------------------------------------------- */
+  /*                             Internal Functions                             */
+  /* -------------------------------------------------------------------------- */
+
+  /* -------------------------------------------------------------------------- */
+  /*                               View Functions                               */
+  /* -------------------------------------------------------------------------- */
+
+  function resourceExists(uint256 _resourceID) external view returns (bool) {
+    return resourceMapping[_resourceID];
+  }
+}

--- a/contracts/resolver/ZNAResolver.sol
+++ b/contracts/resolver/ZNAResolver.sol
@@ -7,12 +7,9 @@ import {AccessControlUpgradeable} from "../oz442/access/AccessControlUpgradeable
 import {IResourceRegistry} from "../interfaces/IResourceRegistry.sol";
 import {IZNSHub} from "../interfaces/IZNSHub.sol";
 import {IZNAResolver} from "../interfaces/IZNAResolver.sol";
+import {ResourceType} from "../libraries/ResourceType.sol";
 
 contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
-  uint256 public constant RESOURCE_TYPE_DAO = 0x1;
-  uint256 public constant RESOURCE_TYPE_STAKING_POOL = 0x2;
-  uint256 public constant RESOURCE_TYPE_FARMING = 0x4;
-
   // Role with who can associate zNA with resource type.
   bytes32 public constant RESOURCE_TYPE_MANAGER_ROLE =
     keccak256(abi.encode("RESOURCE_TYPE_MANAGER"));
@@ -175,9 +172,9 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
     pure
     returns (bool)
   {
-    return (_resourceType == RESOURCE_TYPE_DAO ||
-      _resourceType == RESOURCE_TYPE_STAKING_POOL ||
-      _resourceType == RESOURCE_TYPE_FARMING);
+    return (_resourceType == ResourceType.RESOURCE_TYPE_DAO ||
+      _resourceType == ResourceType.RESOURCE_TYPE_STAKING_POOL ||
+      _resourceType == ResourceType.RESOURCE_TYPE_FARMING);
   }
 
   /**

--- a/contracts/resolver/ZNAResolver.sol
+++ b/contracts/resolver/ZNAResolver.sol
@@ -101,7 +101,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   /**
    * @notice Disassociate zNA with resource type, it will automatically
    *     remove allocated resource ID of given resource type.
-   * @dev Only callable by resource type manager
+   * @dev Only callable by zNAOwner
    * @param _zNA Associating zNA
    * @param _resourceType Single resource type. Check above constants
    */
@@ -111,8 +111,11 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   {
     require(zNSHub.domainExists(_zNA), "Invalid zNA");
     require(_isValidResourceType(_resourceType), "Invalid resource type");
+    require(
+      zNSHub.ownerOf(_zNA) == _msgSender(),
+      "Not authorized: resource type manager"
+    );
     require(_hasResourceType(_zNA, _resourceType), "Should have resource type");
-    _isResourceTypeAuthorized(_zNA, _resourceType);
 
     _disassociateWithResourceType(_zNA, _resourceType);
   }
@@ -213,7 +216,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
       }
       require(
         address(resourceRegistries[_resourceType]) == _msgSender(),
-        "Not authorized: resource type manager"
+        "Only allow to manage registered resource type"
       );
     }
   }
@@ -224,7 +227,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
     uint256 _resourceID
   ) internal {
     if (zNATypes[_zNA] > 0 && !_hasResourceType(_zNA, _resourceType)) {
-      _disassociateWithResourceType(_zNA, _resourceType);
+      _disassociateWithResourceType(_zNA, zNATypes[_zNA]);
     }
 
     // Set/Update ResourceID

--- a/contracts/resolver/ZNAResolver.sol
+++ b/contracts/resolver/ZNAResolver.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.11;
 
 // Uncomment this line to use console.log
@@ -20,7 +20,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   bytes32 public constant RESOURCE_REGISTRY_MANAGER_ROLE =
     keccak256(abi.encode("RESOURCE_REGISTRY_MANAGER"));
 
-  IZNSHub public znsHub;
+  IZNSHub public zNSHub;
 
   // <zNA => ResourceType>
   // ResourceTypes = DAO | StakingPool | Farming | ...
@@ -41,7 +41,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   modifier onlyResourceTypeManagerOrZNAOwner(uint256 _zNA) {
     require(
       hasRole(RESOURCE_TYPE_MANAGER_ROLE, _msgSender()) ||
-        znsHub.ownerOf(_zNA) == _msgSender(),
+        zNSHub.ownerOf(_zNA) == _msgSender(),
       "Not authorized: resource type manager"
     );
     _;
@@ -59,22 +59,22 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   /*                                 Initializer                                */
   /* -------------------------------------------------------------------------- */
 
-  function initialize(IZNSHub _znsHub) public initializer {
+  function initialize(IZNSHub _zNSHub) public initializer {
     __AccessControl_init();
 
     _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     _setupRole(RESOURCE_TYPE_MANAGER_ROLE, _msgSender());
     _setupRole(RESOURCE_REGISTRY_MANAGER_ROLE, _msgSender());
 
-    znsHub = _znsHub;
+    zNSHub = _zNSHub;
   }
 
   /* -------------------------------------------------------------------------- */
   /*                             External Functions                             */
   /* -------------------------------------------------------------------------- */
 
-  function setZNSHub(address _znsHub) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    znsHub = IZNSHub(_znsHub);
+  function setZNSHub(address _zNSHub) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    zNSHub = IZNSHub(_zNSHub);
   }
 
   function setupResourceRegistryManagerRole(address _manager)
@@ -99,7 +99,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
     uint256 _resourceType,
     uint256 _resourceID
   ) external override onlyResourceTypeManagerOrZNAOwner(_zNA) {
-    require(znsHub.ownerOf(_zNA) != address(0), "Invalid zNA");
+    require(zNSHub.domainExists(_zNA), "Invalid zNA");
     require(_isValidResourceType(_resourceType), "Invalid resource type");
     require(
       _doesResourceExist(_resourceType, _resourceID),
@@ -121,7 +121,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
     override
     onlyResourceTypeManagerOrZNAOwner(_zNA)
   {
-    require(znsHub.ownerOf(_zNA) != address(0), "Invalid zNA");
+    require(zNSHub.domainExists(_zNA), "Invalid zNA");
     require(_isValidResourceType(_resourceType), "Invalid resource type");
     require(_hasResourceType(_zNA, _resourceType), "Should have resource type");
 

--- a/contracts/resolver/ZNAResolver.sol
+++ b/contracts/resolver/ZNAResolver.sol
@@ -176,8 +176,7 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
     returns (bool)
   {
     return (_resourceType == ResourceType.RESOURCE_TYPE_DAO ||
-      _resourceType == ResourceType.RESOURCE_TYPE_STAKING_POOL ||
-      _resourceType == ResourceType.RESOURCE_TYPE_FARMING);
+      _resourceType == ResourceType.RESOURCE_TYPE_STAKING_POOL);
   }
 
   /**

--- a/contracts/resolver/ZNAResolver.sol
+++ b/contracts/resolver/ZNAResolver.sol
@@ -47,29 +47,29 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   /*                                 Initializer                                */
   /* -------------------------------------------------------------------------- */
 
-  function initialize(IZNSHub _zNSHub) public initializer {
+  function initialize(IZNSHub zNSHub_) public initializer {
     __AccessControl_init();
 
     _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     _setupRole(RESOURCE_TYPE_MANAGER_ROLE, _msgSender());
     _setupRole(RESOURCE_REGISTRY_MANAGER_ROLE, _msgSender());
 
-    zNSHub = _zNSHub;
+    zNSHub = zNSHub_;
   }
 
   /* -------------------------------------------------------------------------- */
   /*                             External Functions                             */
   /* -------------------------------------------------------------------------- */
 
-  function setZNSHub(address _zNSHub) external onlyRole(DEFAULT_ADMIN_ROLE) {
-    zNSHub = IZNSHub(_zNSHub);
+  function setZNSHub(address zNSHub_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    zNSHub = IZNSHub(zNSHub_);
   }
 
-  function setupResourceRegistryManagerRole(address _manager)
+  function setupResourceRegistryManagerRole(address manager)
     external
     onlyRole(DEFAULT_ADMIN_ROLE)
   {
-    _setupRole(RESOURCE_REGISTRY_MANAGER_ROLE, _manager);
+    _setupRole(RESOURCE_REGISTRY_MANAGER_ROLE, manager);
   }
 
   /**
@@ -77,47 +77,47 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
    *     Single zNA can have multiple different resource type and single
    *     resource ID per each resource type.
    * @dev Only callable by zNA Owner or the resource type manager
-   * @param _zNA Associating zNA
-   * @param _resourceType Single resource type. Check above constants.
-   * @param _resourceID Allocated resource ID. Resource ID can be zDAOId or
+   * @param zNA Associating zNA
+   * @param resourceType Single resource type. Check above constants.
+   * @param resourceID_ Allocated resource ID. Resource ID can be zDAOId or
    *     StakingPoolId or hash Id for other resource
    */
   function associateWithResourceType(
-    uint256 _zNA,
-    uint256 _resourceType,
-    uint256 _resourceID
+    uint256 zNA,
+    uint256 resourceType,
+    uint256 resourceID_
   ) external override {
-    require(zNSHub.domainExists(_zNA), "Invalid zNA");
-    require(_isValidResourceType(_resourceType), "Invalid resource type");
+    require(zNSHub.domainExists(zNA), "Invalid zNA");
+    require(_isValidResourceType(resourceType), "Invalid resource type");
     require(
-      _doesResourceExist(_resourceType, _resourceID),
+      _doesResourceExist(resourceType, resourceID_),
       "Not exist resource"
     );
-    _isResourceTypeAuthorized(_zNA, _resourceType);
+    _isResourceTypeAuthorized(zNA, resourceType);
 
-    _associateWithResourceType(_zNA, _resourceType, _resourceID);
+    _associateWithResourceType(zNA, resourceType, resourceID_);
   }
 
   /**
    * @notice Disassociate zNA with resource type, it will automatically
    *     remove allocated resource ID of given resource type.
    * @dev Only callable by zNAOwner
-   * @param _zNA Associating zNA
-   * @param _resourceType Single resource type. Check above constants
+   * @param zNA Associating zNA
+   * @param resourceType Single resource type. Check above constants
    */
-  function disassociateWithResourceType(uint256 _zNA, uint256 _resourceType)
+  function disassociateWithResourceType(uint256 zNA, uint256 resourceType)
     external
     override
   {
-    require(zNSHub.domainExists(_zNA), "Invalid zNA");
-    require(_isValidResourceType(_resourceType), "Invalid resource type");
+    require(zNSHub.domainExists(zNA), "Invalid zNA");
+    require(_isValidResourceType(resourceType), "Invalid resource type");
     require(
-      zNSHub.ownerOf(_zNA) == _msgSender(),
+      zNSHub.ownerOf(zNA) == _msgSender(),
       "Not authorized: resource type manager"
     );
-    require(_hasResourceType(_zNA, _resourceType), "Should have resource type");
+    require(_hasResourceType(zNA, resourceType), "Should have resource type");
 
-    _disassociateWithResourceType(_zNA, _resourceType);
+    _disassociateWithResourceType(zNA, resourceType);
   }
 
   /**
@@ -125,42 +125,42 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
    *     can have a single resource registry.
    *     Resource registry is responsible to check if resource exists here.
    * @dev Only callable by resource registry manager
-   * @param _resourceType Single resource type. Check above constants
-   * @param _resourceRegistry Address to ResourceRegistry contract
+   * @param resourceType Single resource type. Check above constants
+   * @param resourceRegistry_ Address to ResourceRegistry contract
    */
   function addResourceRegistry(
-    uint256 _resourceType,
-    IResourceRegistry _resourceRegistry
+    uint256 resourceType,
+    IResourceRegistry resourceRegistry_
   ) external override onlyResourceRegistryManager {
-    require(_isValidResourceType(_resourceType), "Invalid resource type");
+    require(_isValidResourceType(resourceType), "Invalid resource type");
 
-    address oldRegistry = address(resourceRegistries[_resourceType]);
+    address oldRegistry = address(resourceRegistries[resourceType]);
     if (oldRegistry != address(0)) {
       // Revole ResoureceTypeManager role from old ResourceRegistry
       _revokeRole(RESOURCE_TYPE_MANAGER_ROLE, oldRegistry);
 
-      emit ResourceRegistryRemoved(_resourceType, oldRegistry);
+      emit ResourceRegistryRemoved(resourceType, oldRegistry);
     }
     // Grant ResoureceTypeManager role to new ResourceRegistry
-    resourceRegistries[_resourceType] = _resourceRegistry;
-    _setupRole(RESOURCE_TYPE_MANAGER_ROLE, address(_resourceRegistry));
+    resourceRegistries[resourceType] = resourceRegistry_;
+    _setupRole(RESOURCE_TYPE_MANAGER_ROLE, address(resourceRegistry_));
 
-    emit ResourceRegistryAdded(_resourceType, address(_resourceRegistry));
+    emit ResourceRegistryAdded(resourceType, address(resourceRegistry_));
   }
 
-  function removeResourceRegistry(uint256 _resourceType)
+  function removeResourceRegistry(uint256 resourceType)
     external
     override
     onlyResourceRegistryManager
   {
-    require(_isValidResourceType(_resourceType), "Invalid resource type");
-    address oldRegistry = address(resourceRegistries[_resourceType]);
+    require(_isValidResourceType(resourceType), "Invalid resource type");
+    address oldRegistry = address(resourceRegistries[resourceType]);
     require(oldRegistry != address(0), "Should have resource registry");
 
-    delete resourceRegistries[_resourceType];
+    delete resourceRegistries[resourceType];
     _revokeRole(RESOURCE_TYPE_MANAGER_ROLE, oldRegistry);
 
-    emit ResourceRegistryRemoved(_resourceType, oldRegistry);
+    emit ResourceRegistryRemoved(resourceType, oldRegistry);
   }
 
   /* -------------------------------------------------------------------------- */
@@ -170,13 +170,13 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
   /**
    * @notice Check if resource type is valid. Only allow for pre-defined types
    */
-  function _isValidResourceType(uint256 _resourceType)
+  function _isValidResourceType(uint256 resourceType)
     internal
     pure
     returns (bool)
   {
-    return (_resourceType == ResourceType.RESOURCE_TYPE_DAO ||
-      _resourceType == ResourceType.RESOURCE_TYPE_STAKING_POOL);
+    return (resourceType == ResourceType.RESOURCE_TYPE_DAO ||
+      resourceType == ResourceType.RESOURCE_TYPE_STAKING_POOL);
   }
 
   /**
@@ -184,105 +184,100 @@ contract ZNAResolver is AccessControlUpgradeable, IZNAResolver {
    *     resource types by binary OR calculation.
    *     If AND(current type, compare type) > 0, then return true.
    */
-  function _hasResourceType(uint256 _zNA, uint256 _resourceType)
+  function _hasResourceType(uint256 zNA, uint256 resourceType)
     internal
     view
     returns (bool)
   {
-    return (zNATypes[_zNA] & _resourceType) > 0;
+    return (zNATypes[zNA] & resourceType) > 0;
   }
 
   /**
    * @notice Check if resource exists by integrating with ResourceRegistry
    */
-  function _doesResourceExist(uint256 _resourceType, uint256 _resourceID)
+  function _doesResourceExist(uint256 resourceType, uint256 resourceID_)
     internal
     view
     returns (bool)
   {
-    IResourceRegistry registry = resourceRegistries[_resourceType];
+    IResourceRegistry registry = resourceRegistries[resourceType];
     assert(address(registry) != address(0));
-    return registry.resourceExists(_resourceID);
+    return registry.resourceExists(resourceID_);
   }
 
-  function _isResourceTypeAuthorized(uint256 _zNA, uint256 _resourceType)
+  function _isResourceTypeAuthorized(uint256 zNA, uint256 resourceType)
     internal
     view
   {
-    if (zNSHub.ownerOf(_zNA) != _msgSender()) {
+    if (zNSHub.ownerOf(zNA) != _msgSender()) {
       if (!hasRole(RESOURCE_TYPE_MANAGER_ROLE, _msgSender())) {
         revert("Not authorized: resource type manager");
       }
       require(
-        address(resourceRegistries[_resourceType]) == _msgSender(),
+        address(resourceRegistries[resourceType]) == _msgSender(),
         "Only allow to manage registered resource type"
       );
     }
   }
 
   function _associateWithResourceType(
-    uint256 _zNA,
-    uint256 _resourceType,
-    uint256 _resourceID
+    uint256 zNA,
+    uint256 resourceType,
+    uint256 resourceID_
   ) internal {
-    if (zNATypes[_zNA] > 0 && !_hasResourceType(_zNA, _resourceType)) {
-      _disassociateWithResourceType(_zNA, zNATypes[_zNA]);
+    if (zNATypes[zNA] > 0 && !_hasResourceType(zNA, resourceType)) {
+      _disassociateWithResourceType(zNA, zNATypes[zNA]);
     }
 
     // Set/Update ResourceID
-    zNATypes[_zNA] = zNATypes[_zNA] | _resourceType;
-    zNAResourceIDs[_zNA][_resourceType] = _resourceID;
+    zNATypes[zNA] = zNATypes[zNA] | resourceType;
+    zNAResourceIDs[zNA][resourceType] = resourceID_;
 
-    emit ResourceAssociated(_zNA, _resourceType, _resourceID);
+    emit ResourceAssociated(zNA, resourceType, resourceID_);
   }
 
-  function _disassociateWithResourceType(uint256 _zNA, uint256 _resourceType)
+  function _disassociateWithResourceType(uint256 zNA, uint256 resourceType)
     internal
   {
-    zNATypes[_zNA] = zNATypes[_zNA] ^ _resourceType;
-    uint256 oldResourceID = zNAResourceIDs[_zNA][_resourceType];
-    delete zNAResourceIDs[_zNA][_resourceType];
+    zNATypes[zNA] = zNATypes[zNA] ^ resourceType;
+    uint256 oldResourceID = zNAResourceIDs[zNA][resourceType];
+    delete zNAResourceIDs[zNA][resourceType];
 
-    emit ResourceDisassociated(_zNA, _resourceType, oldResourceID);
+    emit ResourceDisassociated(zNA, resourceType, oldResourceID);
   }
 
   /* -------------------------------------------------------------------------- */
   /*                               View Functions                               */
   /* -------------------------------------------------------------------------- */
 
-  function hasResourceType(uint256 _zNA, uint256 _resourceType)
+  function hasResourceType(uint256 zNA, uint256 resourceType)
     external
     view
     override
     returns (bool)
   {
-    return _hasResourceType(_zNA, _resourceType);
+    return _hasResourceType(zNA, resourceType);
   }
 
-  function resourceTypes(uint256 _zNA)
+  function resourceTypes(uint256 zNA) external view override returns (uint256) {
+    return zNATypes[zNA];
+  }
+
+  function resourceID(uint256 zNA, uint256 resourceType)
     external
     view
     override
     returns (uint256)
   {
-    return zNATypes[_zNA];
+    return zNAResourceIDs[zNA][resourceType];
   }
 
-  function resourceID(uint256 _zNA, uint256 _resourceType)
-    external
-    view
-    override
-    returns (uint256)
-  {
-    return zNAResourceIDs[_zNA][_resourceType];
-  }
-
-  function resourceRegistry(uint256 _resourceType)
+  function resourceRegistry(uint256 resourceType)
     external
     view
     override
     returns (IResourceRegistry)
   {
-    return resourceRegistries[_resourceType];
+    return resourceRegistries[resourceType];
   }
 }

--- a/scripts/resolver/deploy-znaresolver.ts
+++ b/scripts/resolver/deploy-znaresolver.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { ethers, network, upgrades } from "hardhat";
-import { ZNAResolver } from "../../typechain";
+import { ZNAResolver, ZNAResolver__factory } from "../../typechain";
 import { config } from "../shared/config";
 import { verifyContract } from "../shared/helpers";
 
@@ -18,14 +18,10 @@ async function main() {
     network.name === "mainnet"
   ) {
     console.log("Deploying ZNAResolver proxy contract...");
-    const ZNAResolverFactory = await ethers.getContractFactory("ZNAResolver");
+    const ZNAResolverFactory = new ZNAResolver__factory(deployer);
     const zNAResolver = (await upgrades.deployProxy(
       ZNAResolverFactory,
-      [config[network.name].zNSHub],
-      {
-        kind: "uups",
-        initializer: "__ZNAResolver_init",
-      }
+      [config[network.name].zNSHub]
     )) as ZNAResolver;
     await zNAResolver.deployed();
     console.log(`\ndeployed: ${zNAResolver.address}`);

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -76,3 +76,25 @@ export async function getEvent(
   const firstEvent = events[0];
   return firstEvent;
 }
+
+export type EventMappingType = { [name: string]: ethers.utils.LogDescription };
+
+export async function getAllEvents(
+  tx: ContractTransaction,
+  contract: string,
+  abi: Interface
+): Promise<EventMappingType> {
+  const receipt = await tx.wait();
+  const keys = Object.keys(abi.events);
+  const events = keys.reduce((prev: EventMappingType, current: string) => {
+    const logs = filterLogsWithTopics(receipt.logs, abi.getEventTopic(current), contract);
+    if (logs.length < 1) {
+      return prev;
+    }
+    return {
+      ...prev,
+      [current]: abi.parseLog(logs[0])
+    }
+  }, {});
+  return events;
+}

--- a/test/zNAResolver.spec.ts
+++ b/test/zNAResolver.spec.ts
@@ -6,54 +6,76 @@ import {
 } from "@defi-wonderland/smock";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai, { expect } from "chai";
-import { BigNumber } from "ethers";
+import { BigNumber, ContractTransaction } from "ethers";
 import { ethers } from "hardhat";
 import {
-  IResourceRegistry,
   IZNSHub,
   ZNAResolver,
   ZNAResolver__factory,
 } from "../typechain";
 import IZNSHubAbi from "../artifacts/contracts/interfaces/IZNSHub.sol/IZNSHub.json";
-import IResourceRegistryAbi from "../artifacts/contracts/interfaces/IResourceRegistry.sol/IResourceRegistry.json";
+import { EventMappingType, getAllEvents } from "./helpers";
+import { ResourceType } from "../typechain/ResourceType";
+import { MockResourceRegistry } from "../typechain/MockResourceRegistry";
+import { MockResourceRegistry__factory } from "../typechain/factories/MockResourceRegistry__factory";
 
 chai.use(smock.matchers);
 
+interface TxWithEventsType {
+  tx: ContractTransaction;
+  events: EventMappingType;
+}
+
 describe("zNAResolver", function () {
   let deployer: SignerWithAddress,
-    resourceTypeManager: SignerWithAddress,
     resourceRegistryManager: SignerWithAddress,
+    resourceRegistryManagerNot: SignerWithAddress,
     zNAOwner: SignerWithAddress,
     userA: SignerWithAddress;
 
-  let zNSHub: FakeContract<IZNSHub>,
-    resourceRegistry: FakeContract<IResourceRegistry>,
+  let resourceTypeLib: ResourceType,
+    zNSHub: FakeContract<IZNSHub>,
+    resourceDAORegistry: MockContract<MockResourceRegistry>,
+    resourceStakingRegistry: MockContract<MockResourceRegistry>,
+    resourceRegistryNot: MockContract<MockResourceRegistry>,
     zNAResolver: MockContract<ZNAResolver>;
 
   const wilder_beasts =
-    "0x290422f1f79e710c65e3a72fe8dddc0691bb638c865f5061a5e639cf244ee5ed";
+    BigNumber.from("0x290422f1f79e710c65e3a72fe8dddc0691bb638c865f5061a5e639cf244ee5ed");
+  const fake_wilder_beasts =
+    BigNumber.from("0x290422f1f79e710c65e3a72fe8dddc0691bb638c865f5061a5e639cf244effff");
 
   let RESOURCE_TYPE_DAO: BigNumber,
     RESOURCE_TYPE_STAKING_POOL: BigNumber,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     RESOURCE_TYPE_FARMING: BigNumber;
 
-  const resourceID1 = 1,
-    resourceID2 = 2;
+  let RESOURCE_TYPE_MANAGER_ROLE: string;
+
+  const resourceID1 = BigNumber.from(1),
+    resourceID2 = BigNumber.from(2),
+    notExistingResourceID = BigNumber.from(100);
 
   beforeEach("init setup", async function () {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    [deployer, resourceTypeManager, resourceRegistryManager, zNAOwner, userA] =
+    [deployer,
+    resourceRegistryManager, resourceRegistryManagerNot, zNAOwner, userA] =
       await ethers.getSigners();
 
     zNSHub = (await smock.fake<IZNSHub>(
       IZNSHubAbi.abi
     )) as FakeContract<IZNSHub>;
 
-    resourceRegistry = (await smock.fake(
-      IResourceRegistryAbi.abi
-    )) as FakeContract<IResourceRegistry>;
+    // Deploy ResourceType Library
+    const ResourceTypeLibFactory = await ethers.getContractFactory("ResourceType");
+    resourceTypeLib = await ResourceTypeLibFactory.deploy() as ResourceType;
 
+    // What is Resource Type
+    RESOURCE_TYPE_DAO = await resourceTypeLib.RESOURCE_TYPE_DAO();
+    RESOURCE_TYPE_STAKING_POOL = await resourceTypeLib.RESOURCE_TYPE_STAKING_POOL();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    RESOURCE_TYPE_FARMING = await resourceTypeLib.RESOURCE_TYPE_FARMING();
+
+    // Deploy ZNAResolver
     const ZNAResolverFactory = (await smock.mock<ZNAResolver__factory>(
       "ZNAResolver"
     )) as MockContractFactory<ZNAResolver__factory>;
@@ -61,28 +83,115 @@ describe("zNAResolver", function () {
       (await ZNAResolverFactory.deploy()) as MockContract<ZNAResolver>;
     await zNAResolver.initialize(zNSHub.address);
 
-    RESOURCE_TYPE_DAO = await zNAResolver.RESOURCE_TYPE_DAO();
-    RESOURCE_TYPE_STAKING_POOL = await zNAResolver.RESOURCE_TYPE_STAKING_POOL();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    RESOURCE_TYPE_FARMING = await zNAResolver.RESOURCE_TYPE_FARMING();
-
-    const RESOURCE_TYPE_MANAGER_ROLE =
+    // What is defined Role
+    RESOURCE_TYPE_MANAGER_ROLE =
       await zNAResolver.RESOURCE_TYPE_MANAGER_ROLE();
-    const RESOURCE_REGISTRY_MANAGER_ROLE =
-      await zNAResolver.RESOURCE_REGISTRY_MANAGER_ROLE();
-    await zNAResolver.grantRole(
-      RESOURCE_TYPE_MANAGER_ROLE,
-      resourceTypeManager.address
-    );
-    await zNAResolver.grantRole(
-      RESOURCE_REGISTRY_MANAGER_ROLE,
+
+    // Deploy MockResourceRegistry
+    const MockResourceRegistryFactory = (await smock.mock<MockResourceRegistry__factory>(
+      "MockResourceRegistry"
+    )) as MockContractFactory<MockResourceRegistry__factory>;
+    resourceDAORegistry = (await MockResourceRegistryFactory.deploy(RESOURCE_TYPE_DAO, zNAResolver.address)) as MockContract<MockResourceRegistry>;
+    resourceStakingRegistry = (await MockResourceRegistryFactory.deploy(RESOURCE_TYPE_STAKING_POOL, zNAResolver.address)) as MockContract<MockResourceRegistry>;
+    resourceRegistryNot = (await MockResourceRegistryFactory.deploy(RESOURCE_TYPE_DAO, zNAResolver.address)) as MockContract<MockResourceRegistry>;
+
+    // Grant Roles
+    await zNAResolver.setupResourceRegistryManagerRole(
       resourceRegistryManager.address
     );
+    await zNAResolver.addResourceRegistry(RESOURCE_TYPE_DAO, resourceDAORegistry.address);
+    await zNAResolver.addResourceRegistry(RESOURCE_TYPE_STAKING_POOL, resourceStakingRegistry.address);
 
+    // Fake results
     zNSHub.ownerOf.whenCalledWith(wilder_beasts).returns(zNAOwner.address);
-    resourceRegistry.resourceExists.whenCalledWith(resourceID1).returns(true);
-    resourceRegistry.resourceExists.whenCalledWith(resourceID2).returns(true);
+    zNSHub.domainExists.whenCalledWith(wilder_beasts).returns(true);
+    zNSHub.domainExists.whenCalledWith(fake_wilder_beasts).returns(false);
+    resourceDAORegistry.resourceExists.whenCalledWith(resourceID1).returns(true);
+    resourceDAORegistry.resourceExists.whenCalledWith(resourceID2).returns(true);
+    resourceDAORegistry.resourceExists.whenCalledWith(notExistingResourceID).returns(false);
+    resourceStakingRegistry.resourceExists.whenCalledWith(resourceID1).returns(true);
+    resourceStakingRegistry.resourceExists.whenCalledWith(resourceID2).returns(true);
+    resourceStakingRegistry.resourceExists.whenCalledWith(notExistingResourceID).returns(false);
   });
+
+  async function associateWithResourceType(resourceRegistry: MockContract<MockResourceRegistry>, zNA: BigNumber, resourceType: BigNumber, resourceID: BigNumber): Promise<TxWithEventsType> {
+    const tx = await resourceRegistry.addResource(zNA);
+    const events = await getAllEvents(tx, zNAResolver.address, zNAResolver.interface);
+      
+    expect(tx).to.emit(zNAResolver, "ResourceAssociated")
+      .withArgs(zNA, resourceType, resourceID);
+
+    const hasResourceType = await zNAResolver.hasResourceType(
+      zNA,
+      resourceType
+    );
+    expect(hasResourceType).to.be.equal(true);
+
+    const resourceIDA = await zNAResolver.resourceID(
+      zNA,
+      resourceType
+    );
+    expect(resourceIDA).to.be.equal(resourceID);
+
+    return {tx, events};
+  }
+
+  async function disassociateWithResourceType(zNAOwner: SignerWithAddress, zNA: BigNumber, resourceType: BigNumber): Promise<TxWithEventsType> {
+    const resourceID = await zNAResolver.resourceID(
+      zNA,
+      resourceType
+    );
+
+    const tx = await zNAResolver.connect(zNAOwner)
+      .disassociateWithResourceType(zNA, resourceType);
+    const events = await getAllEvents(tx, zNAResolver.address, zNAResolver.interface);
+
+    expect(tx).to.emit(zNAResolver, "ResourceDisassociated")
+    .withArgs(zNA, resourceType, resourceID);
+
+    const hasResourceType = await zNAResolver.hasResourceType(
+      zNA,
+      resourceType
+    );
+    expect(hasResourceType).to.be.equal(false);
+
+    const resourceIDA = await zNAResolver.resourceID(
+      zNA,
+      resourceType
+    );
+    expect(resourceIDA).to.be.equal(BigNumber.from(0));
+
+    return {tx, events};
+  }
+
+  async function addResourceRegistry(resourceRegistryManager: SignerWithAddress, resourceType: BigNumber, resourceDAORegistry: string): Promise<TxWithEventsType> {
+    const tx = await zNAResolver.connect(resourceRegistryManager)
+      .addResourceRegistry(resourceType, resourceDAORegistry);
+    const events = await getAllEvents(tx, zNAResolver.address, zNAResolver.interface);
+
+    expect(tx).to.emit(zNAResolver, "ResourceRegistryAdded")
+      .withArgs(resourceType, resourceDAORegistry);
+      
+    const resourceRegistryA = await zNAResolver.resourceRegistry(
+      resourceType
+    );
+    expect(resourceRegistryA).to.be.equal(resourceDAORegistry);
+
+    return {tx, events};
+  }
+
+  async function removeResourceRegistry(resourceRegistryManager: SignerWithAddress, resourceType: BigNumber): Promise<TxWithEventsType> {
+    const resourceDAORegistry = await zNAResolver.resourceRegistry(resourceType);
+
+    const tx = await zNAResolver.connect(resourceRegistryManager)
+      .removeResourceRegistry(resourceType);
+    const events = await getAllEvents(tx, zNAResolver.address, zNAResolver.interface);
+
+    expect(tx).to.emit(zNAResolver, "ResourceRegistryRemoved")
+      .withArgs(resourceType, resourceDAORegistry);
+
+    return {tx, events};
+  }
 
   describe("Check for callable permission", async function () {
     it("Only admin can update zNSHub address", async function () {
@@ -109,173 +218,223 @@ describe("zNAResolver", function () {
           .connect(userA)
           .disassociateWithResourceType(wilder_beasts, RESOURCE_TYPE_DAO)
       ).to.be.revertedWith("Not authorized: resource type manager");
+
+      await expect(
+        zNAResolver
+          .connect(zNAOwner)
+          .associateWithResourceType(
+            wilder_beasts,
+            RESOURCE_TYPE_DAO,
+            resourceID1
+          )
+      ).to.be.not.reverted;
+    });
+
+    it("Resource Registry can associate with resource type", async function () {
+      await expect(resourceRegistryNot.addResource(wilder_beasts)).to.be.revertedWith("Not authorized: resource type manager");
+
+      await expect(resourceDAORegistry.addResource(wilder_beasts)).to.be.not.revertedWith;
     });
 
     it("Only resource registry manager can add resource registry", async function () {
       await expect(
         zNAResolver
-          .connect(userA)
-          .addResourceRegistry(RESOURCE_TYPE_DAO, resourceRegistry.address)
+          .connect(resourceRegistryManagerNot)
+          .addResourceRegistry(RESOURCE_TYPE_DAO, resourceDAORegistry.address)
       ).to.be.revertedWith("Not authorized: resource registry manager");
 
       await expect(
         zNAResolver
           .connect(resourceRegistryManager)
-          .addResourceRegistry(RESOURCE_TYPE_DAO, resourceRegistry.address)
+          .addResourceRegistry(RESOURCE_TYPE_DAO, resourceDAORegistry.address)
       ).to.be.not.reverted;
+    });
+  });
+
+  describe("Check for parameter validation", async function () {
+    it("Should allow to use valid zNA", async function () {
+      await expect(
+        zNAResolver.connect(zNAOwner).associateWithResourceType(fake_wilder_beasts, RESOURCE_TYPE_DAO, resourceID1)
+      ).to.be.revertedWith("Invalid zNA");
+    });
+
+    it("Should allow to use valid resource type", async function () {
+      await expect(
+        zNAResolver.connect(zNAOwner).associateWithResourceType(
+          wilder_beasts, RESOURCE_TYPE_DAO.add(RESOURCE_TYPE_STAKING_POOL), resourceID1
+        )
+      ).to.be.revertedWith("Invalid resource type");
+
+      await expect(
+        zNAResolver.connect(resourceRegistryManager).addResourceRegistry(
+          RESOURCE_TYPE_DAO.add(RESOURCE_TYPE_STAKING_POOL),
+          resourceDAORegistry.address
+        )
+      ).to.be.revertedWith("Invalid resource type");
+    });
+
+    it("Should allow to use existing resource ID", async function () {
+      await expect(
+        zNAResolver.connect(zNAOwner).associateWithResourceType(
+          wilder_beasts, RESOURCE_TYPE_DAO, notExistingResourceID
+        )
+      ).to.be.revertedWith("Not exist resource");
     });
   });
 
   describe("Check for resource registry", async function () {
     it("Should add resource registry", async function () {
-      await zNAResolver
-        .connect(resourceRegistryManager)
-        .addResourceRegistry(RESOURCE_TYPE_DAO, resourceRegistry.address);
+      await expect(addResourceRegistry(
+        resourceRegistryManager, 
+        RESOURCE_TYPE_DAO,
+        resourceDAORegistry.address
+      )).to.be.not.reverted;
+    });
 
-      const resourceRegistryA = await zNAResolver.resourceRegistry(
-        RESOURCE_TYPE_DAO
+    it("Should remove resource registry", async function () {
+      await addResourceRegistry(
+        resourceRegistryManager, 
+        RESOURCE_TYPE_DAO,
+        resourceDAORegistry.address
       );
-      expect(resourceRegistryA).to.be.equal(resourceRegistry.address);
+
+      await expect(removeResourceRegistry(
+        resourceRegistryManager,
+        RESOURCE_TYPE_DAO
+      )).to.be.not.reverted;
+    });
+
+    it("Should revoke old resource registry", async function () {
+      // Add resource registry per DAO resource type
+      await addResourceRegistry(resourceRegistryManager, RESOURCE_TYPE_DAO, resourceDAORegistry.address);
+
+      // Add new resource registry per same resource type
+      const {tx} = await addResourceRegistry(resourceRegistryManager, RESOURCE_TYPE_DAO, resourceStakingRegistry.address);
+      
+      expect(tx).to.emit(zNAResolver, "ResourceRegistryRemoved")
+        .withArgs(RESOURCE_TYPE_DAO, resourceDAORegistry.address);
+
+      // Old resource registry should lose role
+      const hasResourceTypeRoleDAO = await zNAResolver.hasRole(RESOURCE_TYPE_MANAGER_ROLE, resourceDAORegistry.address);
+      expect(hasResourceTypeRoleDAO).to.be.equal(false);
+
+      // New resource registry should have new role
+      const hasResourceTypeRoleStaking = await zNAResolver.hasRole(RESOURCE_TYPE_MANAGER_ROLE, resourceStakingRegistry.address);
+      expect(hasResourceTypeRoleStaking).to.be.equal(true);
     });
   });
 
-  describe("Check for association with resource type", async function () {
-    beforeEach(async function () {
-      await zNAResolver
-        .connect(resourceRegistryManager)
-        .addResourceRegistry(RESOURCE_TYPE_DAO, resourceRegistry.address);
-      await zNAResolver
-        .connect(resourceRegistryManager)
-        .addResourceRegistry(
-          RESOURCE_TYPE_STAKING_POOL,
-          resourceRegistry.address
-        );
-    });
-
+  describe("Check for association with resource type/ID", async function () {
     it("Should associate with valid zNA and resource type", async function () {
-      await zNAResolver
-        .connect(resourceTypeManager)
-        .associateWithResourceType(
-          wilder_beasts,
-          RESOURCE_TYPE_DAO,
-          resourceID1
-        );
+      await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID1);
 
-      const hasResourceType = await zNAResolver.hasResourceType(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(hasResourceType).to.be.equal(true);
-
-      const resourceTypes = await zNAResolver.resourceTypes(wilder_beasts);
-      expect(resourceTypes).to.be.equal(RESOURCE_TYPE_DAO);
-
-      const resourceID = await zNAResolver.resourceID(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(resourceID).to.be.equal(resourceID1);
+      await expect(resourceDAORegistry.addResourceExploit(wilder_beasts, RESOURCE_TYPE_STAKING_POOL)).to.be.revertedWith("Only allow to manage registered resource type");
     });
 
-    it("Should update resource ID with same resource type", async function () {
-      await zNAResolver
-        .connect(resourceTypeManager)
-        .associateWithResourceType(
-          wilder_beasts,
-          RESOURCE_TYPE_DAO,
-          resourceID1
-        );
+    it("zNA owner can associate/disassociate with different resource type", async function () {
+      // Associate zNA with DAO resource type
+      await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID1);
 
+      // Associate zNA with Staking resource type
+      const {tx} = await associateWithResourceType(resourceStakingRegistry, wilder_beasts, RESOURCE_TYPE_STAKING_POOL, resourceID1);
+
+      expect(tx).to.emit(zNAResolver, "ResourceDisassociated")
+        .withArgs(wilder_beasts, RESOURCE_TYPE_DAO, resourceID1);
+
+      // zNA should not have DAO association, only have Staking
+      const hasDAOResourceType = await zNAResolver.hasResourceType(wilder_beasts, RESOURCE_TYPE_DAO);
+      expect(hasDAOResourceType).to.be.equal(false);
+
+      // Associate zNA with DAO resource type again
+      const {tx: tx2} = await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID2);
+      
+      expect(tx2).to.emit(zNAResolver, "ResourceDisassociated")
+        .withArgs(wilder_beasts, RESOURCE_TYPE_STAKING_POOL, resourceID1);
+
+      // zNA should only have DAO association
+      const hasStakingResourceType2 = await zNAResolver.hasResourceType(wilder_beasts, RESOURCE_TYPE_STAKING_POOL);
+      expect(hasStakingResourceType2).to.be.equal(false);
+
+      // Disassociate DAO resource type
+      await disassociateWithResourceType(zNAOwner, wilder_beasts, RESOURCE_TYPE_DAO);
+
+      const hasDAOResourceType2 = await zNAResolver.hasResourceType(wilder_beasts, RESOURCE_TYPE_DAO);
+      expect(hasDAOResourceType2).to.be.equal(false);
+    });
+
+    it("Resource Registry should only be able to associate/disassociate resources whose type it manages", async function () {
+      // Resource Registry should be registered with DAO resource type
+      // Let's assume that resource registry for DAO was already registered
+      const resourceRegistry = await zNAResolver.resourceRegistry(RESOURCE_TYPE_DAO);
+      expect(resourceRegistry).to.be.equal(resourceDAORegistry.address);
+
+      // Associate zNA with DAO resource type
+      // zNA should have DAO association
+      await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID1);
+
+      // Associating zNA with Staking resource type should be reverted
       await expect(
-        zNAResolver
-          .connect(resourceTypeManager)
-          .associateWithResourceType(
-            wilder_beasts,
-            RESOURCE_TYPE_DAO,
-            resourceID2
-          )
+        resourceDAORegistry.addResourceExploit(
+          wilder_beasts, RESOURCE_TYPE_STAKING_POOL
+        )
+      ).to.be.revertedWith("Only allow to manage registered resource type");
+
+      // Disassociating zNA from DAO resource type should not be reverted
+      await expect(
+        disassociateWithResourceType(zNAOwner, wilder_beasts, RESOURCE_TYPE_DAO)
       ).to.be.not.reverted;
+
     });
 
-    it("Should associate with valid zNA and single resource type(temporary)", async function () {
-      await zNAResolver
-        .connect(resourceTypeManager)
-        .associateWithResourceType(
-          wilder_beasts,
-          RESOURCE_TYPE_DAO,
-          resourceID1
-        );
+    it("zNA owner and Resource Registry can update resource ID with same resource type without disassociating", async function () {
+      // Associate zNA with DAO resource type
+      await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID1);
 
-      const hasResourceTypeDAO = await zNAResolver.hasResourceType(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(hasResourceTypeDAO).to.be.equal(true);
+      // Update resource ID with same resource type
+      const {tx} = await associateWithResourceType(resourceDAORegistry, wilder_beasts, RESOURCE_TYPE_DAO, resourceID2);
 
-      const resourceTypes = await zNAResolver.resourceTypes(wilder_beasts);
-      // RESOURCE_TYPE_DAO
-      expect(resourceTypes.toNumber()).to.be.equal(Number.parseInt("1", 2));
+      expect(tx).to.not.emit(zNAResolver, "ResourceDisassociated");
 
-      const resourceIDA = await zNAResolver.resourceID(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(resourceIDA).to.be.equal(resourceID1);
+      const resourceIDA = await zNAResolver.resourceID(wilder_beasts, RESOURCE_TYPE_DAO);
+      expect(resourceIDA).to.be.equal(resourceID2);
 
-      // Should not allow to associate multiple resource types for same zNA
-      await expect(
-        zNAResolver
-          .connect(resourceTypeManager)
-          .associateWithResourceType(
-            wilder_beasts,
-            RESOURCE_TYPE_STAKING_POOL,
-            resourceID2
-          )
-      ).to.be.revertedWith("Only support single resource type");
-    });
+      // Associate zNA with DAO resource type by zNA owner
+      const tx2 = await zNAResolver.connect(zNAOwner)
+        .associateWithResourceType(wilder_beasts, RESOURCE_TYPE_STAKING_POOL, resourceID1);
 
-    xit("Should associate with valid zNA and multiple resource types", async function () {
-      await zNAResolver
-        .connect(resourceTypeManager)
-        .associateWithResourceType(
-          wilder_beasts,
-          RESOURCE_TYPE_DAO,
-          resourceID1
-        );
-      await zNAResolver
-        .connect(resourceTypeManager)
-        .associateWithResourceType(
-          wilder_beasts,
-          RESOURCE_TYPE_STAKING_POOL,
-          resourceID2
-        );
+      expect(tx2).to.emit(zNAResolver, "ResourceDisassociated")
+        .withArgs(wilder_beasts, RESOURCE_TYPE_DAO, resourceID2);
 
-      const hasResourceTypeDAO = await zNAResolver.hasResourceType(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(hasResourceTypeDAO).to.be.equal(true);
+      // Update resource ID with same resource type by zNA owner
+      const tx3 = await zNAResolver.connect(zNAOwner)
+        .associateWithResourceType(wilder_beasts, RESOURCE_TYPE_STAKING_POOL, resourceID2);
 
-      const hasResourceTypeStaking = await zNAResolver.hasResourceType(
-        wilder_beasts,
-        RESOURCE_TYPE_STAKING_POOL
-      );
-      expect(hasResourceTypeStaking).to.be.equal(true);
+      expect(tx3).to.not.emit(zNAResolver, "ResourceDisassociated");
 
-      const resourceTypes = await zNAResolver.resourceTypes(wilder_beasts);
-      // RESOURCE_TYPE_DAO | RESOURCE_TYPE_STAKING_POOL
-      expect(resourceTypes.toNumber()).to.be.equal(Number.parseInt("11", 2));
-
-      const resourceIDA = await zNAResolver.resourceID(
-        wilder_beasts,
-        RESOURCE_TYPE_DAO
-      );
-      expect(resourceIDA).to.be.equal(resourceID1);
-      const resourceIDB = await zNAResolver.resourceID(
-        wilder_beasts,
-        RESOURCE_TYPE_STAKING_POOL
-      );
+      const resourceIDB = await zNAResolver.resourceID(wilder_beasts, RESOURCE_TYPE_STAKING_POOL);
       expect(resourceIDB).to.be.equal(resourceID2);
+    });
+  });
+
+  describe("Check for upgradability", async function () {
+    beforeEach("init setup", async function () {
+      // todo
+    });
+
+    it("Should preserve storage layout", async function () {
+      // todo
+      // Associate zNA with DAO resource type
+      // Upgrade to v2
+      // zNA should have DAO association
+    });
+
+    it("Should be able to associate new resource type", async function () {
+      // todo
+      // Associate zNA with DAO resource type
+      // Upgrade to v2 which has new resource type(Farming)
+      // zNA should have DAO association
+      // Associate zNA with new resource type
+      // zNA should have association with new resource type, not for DAO
     });
   });
 });

--- a/test/zNAResolver.spec.ts
+++ b/test/zNAResolver.spec.ts
@@ -46,9 +46,7 @@ describe("zNAResolver", function () {
     BigNumber.from("0x290422f1f79e710c65e3a72fe8dddc0691bb638c865f5061a5e639cf244effff");
 
   let RESOURCE_TYPE_DAO: BigNumber,
-    RESOURCE_TYPE_STAKING_POOL: BigNumber,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    RESOURCE_TYPE_FARMING: BigNumber;
+    RESOURCE_TYPE_STAKING_POOL: BigNumber;
 
   let RESOURCE_TYPE_MANAGER_ROLE: string;
 
@@ -72,8 +70,6 @@ describe("zNAResolver", function () {
     // What is Resource Type
     RESOURCE_TYPE_DAO = await resourceTypeLib.RESOURCE_TYPE_DAO();
     RESOURCE_TYPE_STAKING_POOL = await resourceTypeLib.RESOURCE_TYPE_STAKING_POOL();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    RESOURCE_TYPE_FARMING = await resourceTypeLib.RESOURCE_TYPE_FARMING();
 
     // Deploy ZNAResolver
     const ZNAResolverFactory = (await smock.mock<ZNAResolver__factory>(

--- a/test/zNAResolver.spec.ts
+++ b/test/zNAResolver.spec.ts
@@ -415,26 +415,4 @@ describe("zNAResolver", function () {
       expect(resourceIDB).to.be.equal(resourceID2);
     });
   });
-
-  describe("Check for upgradability", async function () {
-    beforeEach("init setup", async function () {
-      // todo
-    });
-
-    it("Should preserve storage layout", async function () {
-      // todo
-      // Associate zNA with DAO resource type
-      // Upgrade to v2
-      // zNA should have DAO association
-    });
-
-    it("Should be able to associate new resource type", async function () {
-      // todo
-      // Associate zNA with DAO resource type
-      // Upgrade to v2 which has new resource type(Farming)
-      // zNA should have DAO association
-      // Associate zNA with new resource type
-      // zNA should have association with new resource type, not for DAO
-    });
-  });
 });


### PR DESCRIPTION
* use `domainExists` to check if zNA exists
* revoke `RESOURCE_TYPE_MANAGER_ROLE` role from old resource registry when add new one
* disassociate zNA if associate with different resource type
* only allow to manage registered resource type: DAO resource registry can't associate with Staking resource type
* only zNA owner can disassociate zNA with resource type: resource registry can't disassociate when delete resource itself
* use Resource Type constants as library
* update unit test